### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+### 概要
+- rugbyPlayer_databaseに対するREAD機能の実装
+- Controller/Servise/Mapper/Responseクラスの実装
+- 全件取得・クエリ文字列で一定身長以上の選手名・ポジションを取得
+### 動作確認
+[database]  
+<img width="300" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/1871a8cd-82f1-43ac-86cc-b1b750003a2a">  
+[全件取得]   
+<img width="221" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/99a9e0e9-e7f8-4522-ac2f-6822dd1e7fb6">  
+以下省略  
+
+[一定身長以上]  
+<img width="214" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/0d7018b6-5caf-4fce-bbec-4feefae394ba">
+
+
+
+
+


### PR DESCRIPTION
### 概要は以下です
- rugbyPlayer_databaseに対するREAD機能を実装
- Controller/Service/Mapper/Responseクラスの実装
- 全件取得・一定身長以上の選手名、ポジションの取得
### 動作確認
[database]  
<img width="300" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/cdfaa851-ca80-44df-89e2-12959ab7724e">  
全件取得  
<img width="209" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/808d553d-bc07-433f-9150-bb108cbe5fb3"> 
以下省略  
 
一定身長以上の選手名・ポジション  
<img width="209" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/6b8b25b4-aa94-4405-a14d-3dac69552646">  

以上です



