### PR TITLE
RugbyPlayerFetchService・RugbyPlayerInitializerテストの実装

### DIFF
--- a/src/test/java/com/raisetech/api/sean/service/RugbyPlayerFetchServiceTest.java
+++ b/src/test/java/com/raisetech/api/sean/service/RugbyPlayerFetchServiceTest.java
@@ -1,0 +1,56 @@
+package com.raisetech.api.sean.service;//package com.raisetech.api.sean.service;
+
+import com.raisetech.api.sean.entity.RugbyPlayer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class RugbyPlayerFetchServiceTest {
+
+    @Autowired
+    private RugbyPlayerFetchService rugbyPlayerFetchService;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private MockRestServiceServer mockServer;
+
+    @BeforeEach
+    public void setUp() {
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+    }
+
+    @Test
+    public void 外部APIへGETリクエストを送信し返されたJSONデータが正しくデシリアライズされること() {
+        ReflectionTestUtils.setField(rugbyPlayerFetchService, "API_KEY", "MOCK_API_KEY");
+        String apiUrl = "https://api.sportradar.us/rugby-union/trial/v3/ja/competitors/sr:competitor:7955/profile.json?api_key=MOCK_API_KEY";
+
+        String responseBody = "{ \"team\": \"brave_blossoms\", \"players\": [ { \"id\": \"1\", \"name\": \"Sinki, Gen\", \"height\": 180, \"weight\": 95, \"type\": \"BR\" }, { \"id\": \"2\", \"name\": \"Kenki, Fukuoka\", \"height\": 170, \"weight\": 75, \"type\": \"WTB\" } ] }";
+
+        mockServer.expect(requestTo(apiUrl))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+        List<RugbyPlayer> players = rugbyPlayerFetchService.getDataFromExternalApi();
+        List<RugbyPlayer> expected = List.of(new RugbyPlayer("1", "Sinki, Gen", 180, 95, "BR"), new RugbyPlayer("2", "Kenki, Fukuoka", 170, 75, "WTB"));
+        assertEquals(expected, players);
+
+        mockServer.verify();
+    }
+}

--- a/src/test/java/com/raisetech/api/sean/service/RugbyPlayerFetchServiceTest.java
+++ b/src/test/java/com/raisetech/api/sean/service/RugbyPlayerFetchServiceTest.java
@@ -1,4 +1,4 @@
-package com.raisetech.api.sean.service;//package com.raisetech.api.sean.service;
+package com.raisetech.api.sean.service;
 
 import com.raisetech.api.sean.entity.RugbyPlayer;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,8 +41,27 @@ public class RugbyPlayerFetchServiceTest {
         ReflectionTestUtils.setField(rugbyPlayerFetchService, "API_KEY", "MOCK_API_KEY");
         String apiUrl = "https://api.sportradar.us/rugby-union/trial/v3/ja/competitors/sr:competitor:7955/profile.json?api_key=MOCK_API_KEY";
 
-        String responseBody = "{ \"team\": \"brave_blossoms\", \"players\": [ { \"id\": \"1\", \"name\": \"Sinki, Gen\", \"height\": 180, \"weight\": 95, \"type\": \"BR\" }, { \"id\": \"2\", \"name\": \"Kenki, Fukuoka\", \"height\": 170, \"weight\": 75, \"type\": \"WTB\" } ] }";
-
+        String responseBody = """
+                {
+                   "team": "brave_blossoms",
+                   "players": [
+                      {
+                         "id": "1",
+                         "name": "Sinki, Gen",
+                         "height": 180,
+                         "weight": 95,
+                         "type": "BR"
+                      },
+                      {
+                         "id": "2",
+                         "name": "Kenki, Fukuoka",
+                         "height": 170,
+                         "weight": 75,
+                         "type": "WTB"
+                      }
+                   ]
+                }
+                """;
         mockServer.expect(requestTo(apiUrl))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));

--- a/src/test/java/com/raisetech/api/sean/service/RugbyPlayerInitializerTest.java
+++ b/src/test/java/com/raisetech/api/sean/service/RugbyPlayerInitializerTest.java
@@ -1,0 +1,37 @@
+package com.raisetech.api.sean.service;
+
+import com.raisetech.api.sean.entity.RugbyPlayer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RugbyPlayerInitializerTest {
+
+    @Mock
+    private RugbyPlayerFetchService rugbyPlayerFetchService;
+
+    @Mock
+    private RugbyPlayerInfoService rugbyPlayerInfoService;
+
+    @InjectMocks
+    private RugbyPlayerInitializer rugbyPlayerInitializer;
+
+    @Test
+    public void アプリ起動時にFetchServiceで取得した外部APIのデータをInfoServiceを使用してデータベースに投入できること() {
+        RugbyPlayer player = new RugbyPlayer("1", "Sinki, Gen", 180, 80, "BR");
+        List<RugbyPlayer> playersList = List.of(player);
+        doReturn(playersList).when(rugbyPlayerFetchService).getDataFromExternalApi();
+
+        rugbyPlayerInitializer.init();
+
+        verify(rugbyPlayerFetchService, times(1)).getDataFromExternalApi();
+        verify(rugbyPlayerInfoService, times(1)).insertRugbyPlayers(playersList);
+    }
+}


### PR DESCRIPTION
### 概要
`RugbyPlayerFetchService`は外部のAPIからラグビー選手のデータをJSONで取得するクラス
`RugbyPlayerInitializer`はアプリケーション起動時にFetchServiceクラスが取得したデータをInfoServiceクラスのinsertRugbyPlayersメソッドを呼び出してデータベースに保存するクラス
以上２つのクラスの単体テストを実装しました。
### 動作確認
RugbyPlayerFetchServiceTest
<img width="500" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/26140ff2-5663-4238-bbd7-0938cfc1cfc7">  

RugbyPlayerInitializerTest
<img width="500" alt="image" src="https://github.com/Satoru-Oki/9th-topic-raisetech/assets/143796169/5870918a-ae41-4bff-9323-0b9d9f19f074">  
いずれもテストはパスしました。  
### 備考
RugbyPlayerFetchServiceのテストは講義で学習した方法ではできませんでしたので、いろいろ調べてこの方法で実装しましたが、適切であるかは自信がありません。

